### PR TITLE
feat: add list argument to scene

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -81,6 +81,15 @@ pub enum Recording {
     Toggle,
 }
 
+// Define the SceneAction enum for different scene actions
+#[derive(Subcommand)]
+pub enum SceneAction {
+    Switch {
+        scene_name: String,
+    },
+    List,
+}
+
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 pub struct Cli {
@@ -96,8 +105,8 @@ pub struct Cli {
 pub enum Commands {
     Info,
     Scene {
-        switch_placeholder: String, // NOTE: just for args positioning
-        scene_name: String,
+        #[clap(subcommand)]
+        action: SceneAction,
     },
     SceneCollection {
         switch_placeholder: String, // NOTE: just for args positioning

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,15 +20,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     match &cli.command {
-        Commands::Scene {
-            switch_placeholder,
-            scene_name,
-        } => {
-            // let scene_name = &args[3];
-            let res = client.scenes().set_current_program_scene(scene_name).await;
-            println!("Set current scene: {} {}", switch_placeholder, scene_name);
-            println!("Result: {:?}", res);
-        }
+        Commands::Scene { action } => match action {
+            SceneAction::Switch { scene_name } => {
+                let res = client.scenes().set_current_program_scene(scene_name).await;
+                println!("Switched to scene: {}", scene_name);
+                println!("Result: {:?}", res);
+            }
+            SceneAction::List => {
+                let res = client.scenes().list().await?;
+                println!("Scenes: {:?}", res);
+            }
+        },
 
         Commands::SceneCollection {
             switch_placeholder,


### PR DESCRIPTION
This PR adds support for listing scenes.

Usage:
```bash
obs-cmd scene list
```

- Modify switch_placeholder to support `switch` and `list`  
- Add `obws` list API